### PR TITLE
Fix `detect_entities` with varying number of entities per doc

### DIFF
--- a/R/detect_entities.R
+++ b/R/detect_entities.R
@@ -25,7 +25,7 @@ function(
         out <- comprehendHTTP(action = "BatchDetectEntities", body = bod, ...)
         # build response data frame
         x <- out$ResultList
-        x <- cbind(Index = x$Index, do.call("rbind", x$Entities))
+        x <- cbind(Index = rep(x$Index, unlist(lapply(x$Entities, nrow))), do.call("rbind", x$Entities))
         return(structure(x, ErrorList = out$ErrorList))
     } else {
         bod <- list(Text = text, LanguageCode = language)


### PR DESCRIPTION
This fixes issue #2 (and #9).

Outstanding:

- [ ] Document the fix in [NEWS.md](https://github.com/cloudyr/aws.comprehend/blob/master/NEWS.md) with a parenthetical reference to the issue number being addressed
- [ ] Add a relevant example and run `devtools::document()` to update documentation
- [ ] make sure `R CMD check` runs without error before submitting the PR

