### PR TITLE
Better error message when credentials are not provided

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,9 @@
 # aws.comprehend 0.1.3 (in development)
 
-* @antoine-sachet taking over as maintainer
 * **New feature:** `detect_syntax` function to perform syntax analysis (#14)
+* Better error message when AWS credentials are not provided (#15)
 * Fix missing import of `locate_credential` from `aws.signature` (#5)
+* @antoine-sachet taking over as maintainer
 
 # aws.comprehend 0.1.2
 

--- a/R/http.R
+++ b/R/http.R
@@ -36,6 +36,11 @@ function(
     secret <- credentials[["secret"]]
     session_token <- credentials[["session_token"]]
     region <- credentials[["region"]]
+    
+    # Fail early if credentials cannot be found
+    if ((is.null(key) || is.null(secret)) && is.null(session_token)) {
+      stop("Unable to locate AWS credentials.")
+    }
 
     # generate request signature
     d_timestamp <- format(Sys.time(), "%Y%m%dT%H%M%SZ", tz = "UTC")


### PR DESCRIPTION
Fail early when AWS credentials are not found.

